### PR TITLE
Fix for having comments and text as root items

### DIFF
--- a/ruff_cgx/template_formatter.py
+++ b/ruff_cgx/template_formatter.py
@@ -247,7 +247,7 @@ def format_template(template_node) -> tuple[list[str], tuple[int, int]]:
 
     # Comment and TextElement nodes don't have an 'end' attribute
     # For these, we compute the end from the content by counting newlines
-    if isinstance(template_node, (Comment, TextElement)):
+    if not hasattr(template_node, "end"):
         # Count newlines in content to determine end line
         newline_count = template_node.content.count("\n")
         end = start + newline_count + 1

--- a/ruff_cgx/template_formatter.py
+++ b/ruff_cgx/template_formatter.py
@@ -242,8 +242,17 @@ def format_template(template_node) -> tuple[list[str], tuple[int, int]]:
 
     Uses batch formatting for all Python expressions to improve performance.
     """
-    # Find beginning and end of script block
-    start, end = template_node.location[0] - 1, template_node.end[0]
+    # Find beginning of the node (0-indexed)
+    start = template_node.location[0] - 1
+
+    # Comment and TextElement nodes don't have an 'end' attribute
+    # For these, we compute the end from the content by counting newlines
+    if isinstance(template_node, (Comment, TextElement)):
+        # Count newlines in content to determine end line
+        newline_count = template_node.content.count("\n")
+        end = start + newline_count + 1
+    else:
+        end = template_node.end[0]
 
     # Collect all expressions and batch format them
     expressions = collect_expressions(template_node)

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -723,6 +723,118 @@ def test_format_multiline_dict_template():
     assert formatted == expected
 
 
+def test_format_comment_as_root_node():
+    """Test formatting cgx files with a multiline comment as a root node."""
+    content = textwrap.dedent(
+        """
+        <!--
+
+        This is a root comment
+        that spans multiple lines
+        to test multiline handling -->
+        <script>
+        from collagraph import Component
+        class Node(Component):
+        	pass
+        </script>
+        """
+    ).lstrip()
+
+    formatted = format_cgx_content(content)
+
+    expected = textwrap.dedent(
+        """
+        <!--
+
+        This is a root comment
+        that spans multiple lines
+        to test multiline handling -->
+
+        <script>
+        from collagraph import Component
+
+
+        class Node(Component):
+            pass
+        </script>
+        """
+    ).lstrip()
+
+    assert formatted == expected
+
+
+def test_format_comment_as_root_node_with_template():
+    """Test formatting cgx files with a comment and template as root nodes."""
+    content = textwrap.dedent(
+        """
+        <!-- Root comment -->
+        <template>
+          <item />
+        </template>
+
+        <script>
+        from collagraph import Component
+        class Node(Component):
+        	pass
+        </script>
+        """
+    ).lstrip()
+
+    formatted = format_cgx_content(content)
+
+    expected = textwrap.dedent(
+        """
+        <!-- Root comment -->
+
+        <template>
+          <item />
+        </template>
+
+        <script>
+        from collagraph import Component
+
+
+        class Node(Component):
+            pass
+        </script>
+        """
+    ).lstrip()
+
+    assert formatted == expected
+
+
+def test_format_text_as_root_node():
+    """Test formatting cgx files with text as a root node."""
+    content = textwrap.dedent(
+        """
+        Some root text
+        <script>
+        from collagraph import Component
+        class Node(Component):
+        	pass
+        </script>
+        """
+    ).lstrip()
+
+    formatted = format_cgx_content(content)
+
+    expected = textwrap.dedent(
+        """
+        Some root text
+
+        <script>
+        from collagraph import Component
+
+
+        class Node(Component):
+            pass
+        </script>
+        """
+    ).lstrip()
+
+    assert formatted == expected
+
+
 def test_format_multiline_dict_template_multi_attrs():
     content = textwrap.dedent(
         """


### PR DESCRIPTION
Problem was an AttributeError:
```
Error formatting ./file.cgx: 'Comment' object has no attribute 'end'
Traceback (most recent call last):
  File "./.venv/lib/python3.13/site-packages/ruff_cgx/formatter.py", line 124, in format_cgx_content
    format_template(node) for node in parsed.template_nodes
    ~~~~~~~~~~~~~~~^^^^^^
  File "./.venv/lib/python3.13/site-packages/ruff_cgx/template_formatter.py", line 246, in format_template
    start, end = template_node.location[0] - 1, template_node.end[0]
                                                ^^^^^^^^^^^^^^^^^
AttributeError: 'Comment' object has no attribute 'end'
```