### PR TITLE
Add help message given bad arguments are received

### DIFF
--- a/ruff_cgx/__main__.py
+++ b/ruff_cgx/__main__.py
@@ -150,9 +150,9 @@ def main(argv=None):
 
     parser = argparse.ArgumentParser(
         description="Lint and format cgx files with ruff",
-        epilog="Environment: Set RUFF_COMMAND to use a custom ruff executable.",
+        epilog="Environment: Set RUFF_COMMAND to use a custom ruff executable."
     )
-    subcommand = parser.add_subparsers(dest="command")
+    subcommand = parser.add_subparsers(dest="command", required=True)
 
     lint_parser = subcommand.add_parser("check")
     lint_parser.add_argument(
@@ -176,6 +176,9 @@ def main(argv=None):
         help="path(s) of files and/or folders to format",
     )
 
+    # Explicit help subcommand (separate from -h/--help)
+    subcommand.add_parser("help", help="Show this help message and exit")
+
     args = parser.parse_args(argv)
 
     match args.command:
@@ -183,13 +186,12 @@ def main(argv=None):
             code = run_check_command(args)
         case "format":
             code = run_format_command(args)
-        case _:
+        case "help":
             parser.print_help()
-            exit(1)
+            exit(0)
 
     if code:
         exit(code)
-
 
 if __name__ == "__main__":
     main()

--- a/ruff_cgx/__main__.py
+++ b/ruff_cgx/__main__.py
@@ -150,7 +150,7 @@ def main(argv=None):
 
     parser = argparse.ArgumentParser(
         description="Lint and format cgx files with ruff",
-        epilog="Environment: Set RUFF_COMMAND to use a custom ruff executable."
+        epilog="Environment: Set RUFF_COMMAND to use a custom ruff executable.",
     )
     subcommand = parser.add_subparsers(dest="command", required=True)
 
@@ -186,6 +186,7 @@ def main(argv=None):
 
     if code:
         exit(code)
+
 
 if __name__ == "__main__":
     main()

--- a/ruff_cgx/__main__.py
+++ b/ruff_cgx/__main__.py
@@ -183,6 +183,9 @@ def main(argv=None):
             code = run_check_command(args)
         case "format":
             code = run_format_command(args)
+        case _:
+            parser.print_help()
+            exit(1)
 
     if code:
         exit(code)

--- a/ruff_cgx/__main__.py
+++ b/ruff_cgx/__main__.py
@@ -176,9 +176,6 @@ def main(argv=None):
         help="path(s) of files and/or folders to format",
     )
 
-    # Explicit help subcommand (separate from -h/--help)
-    subcommand.add_parser("help", help="Show this help message and exit")
-
     args = parser.parse_args(argv)
 
     match args.command:
@@ -186,9 +183,6 @@ def main(argv=None):
             code = run_check_command(args)
         case "format":
             code = run_format_command(args)
-        case "help":
-            parser.print_help()
-            exit(0)
 
     if code:
         exit(code)


### PR DESCRIPTION
# Overview
Previously, given there were no arguments provided to running the following

```
uv run ruff-cgx
```

We would see the following error

<img width="909" height="238" alt="image" src="https://github.com/user-attachments/assets/ed66a26a-1cc4-4b55-9a74-a718dcaefe93" />

This PR makes it such that instead we get a help message with intended usage.

# Steps to test
1. Run `uv run ruff-cgx`